### PR TITLE
Fixes for 2 possible exceptions from the SDK

### DIFF
--- a/rapidconnect/src/test/java/com/rapidapi/rapidconnect/RapidApiConnectTest.java
+++ b/rapidconnect/src/test/java/com/rapidapi/rapidconnect/RapidApiConnectTest.java
@@ -1,0 +1,53 @@
+package com.rapidapi.rapidconnect;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class RapidApiConnectTest {
+  private static final String PROJECT = "Rapid_Api_Unit_Tests";
+  private static final String KEY = "ff0df8fb-2cd5-448f-be44-44ec3c318338";
+
+  private RapidApiConnect testObject;
+
+  @Before
+  public void setUp() throws Exception {
+    testObject = new RapidApiConnect(PROJECT, KEY);
+  }
+
+  @Test
+  public void blockUrlBuilding() {
+    String actual = RapidApiConnect.blockUrlBuild("pck", "blk");
+    assertEquals("https://rapidapi.io/connect/pck/blk", actual);
+  }
+
+  @Test
+  public void zeroParameterServiceCallShouldNotThrowIllegalArgumentExceptions() {
+    try {
+      Map<String, Object> result = testObject.call("HackerNews", "getJobStories", Collections.<String, Argument>emptyMap());
+      assertNotNull(result);
+      assertNotNull(result.get("success"));
+    } catch (Throwable e) {
+      fail("No exception expected: " + e);
+    }
+  }
+
+  @Test
+  public void nullBodyMapIsHandledGracefully() {
+    try {
+      Map<String, Object> result = testObject.call("HackerNews", "getJobStories", null);
+      assertNotNull(result);
+      assertNotNull(result.get("success"));
+    } catch (Throwable e) {
+      fail("No exception expected: " + e);
+    }
+  }
+
+}


### PR DESCRIPTION
For the **java.lang.IllegalStateException: Multipart body must have at least one part.**
- Sent an empty body when the body map is empty.

For the possible **java.lang.NullPointerException** 
- Added a null check to treat is the same as an empty map.

Also added a unit test for correct formatting of the URL.